### PR TITLE
Adjust API calls to request maximum number of results allowed

### DIFF
--- a/mastodon_to_sqlite/client.py
+++ b/mastodon_to_sqlite/client.py
@@ -70,24 +70,34 @@ class MastodonClient:
     def accounts_followers(
         self, account_id: str
     ) -> Generator[Tuple[PreparedRequest, Response], None, None]:
-        return self.request_paginated("GET", f"accounts/{account_id}/followers")
+        return self.request_paginated(
+            "GET", f"accounts/{account_id}/followers", params={"limit": "80"}
+        )
 
     def accounts_following(
         self, account_id: str
     ) -> Generator[Tuple[PreparedRequest, Response], None, None]:
-        return self.request_paginated("GET", f"accounts/{account_id}/following")
+        return self.request_paginated(
+            "GET", f"accounts/{account_id}/following", params={"limit": "80"}
+        )
 
     def accounts_statuses(
         self, account_id: str
     ) -> Generator[Tuple[PreparedRequest, Response], None, None]:
-        return self.request_paginated("GET", f"accounts/{account_id}/statuses")
+        return self.request_paginated(
+            "GET", f"accounts/{account_id}/statuses", params={"limit": "40"}
+        )
 
     def bookmarks(
         self,
     ) -> Generator[Tuple[PreparedRequest, Response], None, None]:
-        return self.request_paginated("GET", "bookmarks")
+        return self.request_paginated(
+            "GET", "bookmarks", params={"limit": "40"}
+        )
 
     def favourites(
         self,
     ) -> Generator[Tuple[PreparedRequest, Response], None, None]:
-        return self.request_paginated("GET", "favourites")
+        return self.request_paginated(
+            "GET", "favourites", params={"limit": "40"}
+        )


### PR DESCRIPTION
I don't know if this is interesting to you, but I noticed that the result [limit](https://docs.joinmastodon.org/methods/accounts/#following) [for](https://docs.joinmastodon.org/methods/accounts/#followers) [the](https://docs.joinmastodon.org/methods/accounts/#statuses) [various](https://docs.joinmastodon.org/methods/bookmarks/#get) [APIs](https://docs.joinmastodon.org/methods/favourites/#get) can be configured to double the default value. Seems useful to take advantage of the higher limit wherever possible.