### PR TITLE
🐛 #10 — Fixed issue with Mastodon rate limiting

### DIFF
--- a/mastodon_to_sqlite/client.py
+++ b/mastodon_to_sqlite/client.py
@@ -74,9 +74,7 @@ class MastodonClient:
                 reset_at = datetime.datetime.fromisoformat(
                     response.headers["X-RateLimit-Reset"]
                 )
-                reset_in_secs = (reset_at - get_utc_now()).seconds
-                # breakpoint()
-                sleep(reset_in_secs)
+                sleep((reset_at - get_utc_now()).seconds)
 
             next_url = response.links["next"]["url"]
             next_path = next_url.replace(f"{self.api_url}/", "")

--- a/mastodon_to_sqlite/client.py
+++ b/mastodon_to_sqlite/client.py
@@ -70,6 +70,9 @@ class MastodonClient:
                 next_path = None
                 continue
 
+            # If the Mastodon server is reporting rate limit remaining of one
+            # more call, then we should sleep until we are free to call again.
+            # See docs: <https://docs.joinmastodon.org/api/rate-limits/>
             if response.headers.get("X-RateLimit-Remaining") == "1":
                 reset_at = datetime.datetime.fromisoformat(
                     response.headers["X-RateLimit-Reset"]

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,3 +1,5 @@
+import datetime
+
 import responses
 from responses import matchers
 
@@ -52,7 +54,11 @@ def test_mastodon_client__request_paginated():
         responses.Response(
             method="GET",
             url=url,
-            headers={"Link": f'<{url}?max_id=9876543210>; rel="next"'},
+            headers={
+                "Link": f'<{url}?max_id=9876543210>; rel="next"',
+                "X-RateLimit-Limit": "100",
+                "X-RateLimit-Remaining": "99",
+            },
             json=fixtures.ACCOUNT_ONE,
         )
     )
@@ -60,7 +66,11 @@ def test_mastodon_client__request_paginated():
         responses.Response(
             method="GET",
             url=url,
-            headers={"Link": f'<{url}>; rel="previous"'},
+            headers={
+                "Link": f'<{url}>; rel="previous"',
+                "X-RateLimit-Limit": "100",
+                "X-RateLimit-Remaining": "98",
+            },
             match=[matchers.query_string_matcher("max_id=9876543210")],
             json=fixtures.ACCOUNT_TWO,
         )
@@ -70,3 +80,58 @@ def test_mastodon_client__request_paginated():
     list(client.request_paginated("GET", path))
 
     assert len(responses.calls) == 2
+
+
+@responses.activate
+def test_mastodon_client__request_paginated__rate_limit(mocker):
+    mock_now = datetime.datetime.utcnow()
+    rate_limit_reset_at = mock_now + datetime.timedelta(
+        hours=1, minutes=1, seconds=30
+    )
+
+    mocker.patch(
+        "mastodon_to_sqlite.client.get_utc_now",
+        return_value=mock_now,
+    )
+
+    mock_sleep = mocker.patch(
+        "mastodon_to_sqlite.client.sleep", return_value=None
+    )
+
+    domain = "mastodon.example"
+    access_token = "IAmAnAccessToken"
+    path = "accounts/verify_credentials"
+    url = f"https://{domain}/api/v1/{path}"
+
+    responses.add(
+        responses.Response(
+            method="GET",
+            url=url,
+            headers={
+                "Link": f'<{url}?max_id=9876543210>; rel="next"',
+                "X-RateLimit-Limit": "100",
+                "X-RateLimit-Remaining": "1",
+                "X-RateLimit-Reset": rate_limit_reset_at.isoformat(),
+            },
+            json=fixtures.ACCOUNT_ONE,
+        )
+    )
+    responses.add(
+        responses.Response(
+            method="GET",
+            url=url,
+            headers={
+                "Link": f'<{url}>; rel="previous"',
+                "X-RateLimit-Limit": "100",
+                "X-RateLimit-Remaining": "99",
+                "X-RateLimit-Reset": rate_limit_reset_at.isoformat(),
+            },
+            match=[matchers.query_string_matcher("max_id=9876543210")],
+            json=fixtures.ACCOUNT_TWO,
+        )
+    )
+
+    client = MastodonClient(domain=domain, access_token=access_token)
+    list(client.request_paginated("GET", path))
+
+    mock_sleep.assert_called_once_with(3690)


### PR DESCRIPTION
People with large amount of status, followers, followings, etc. were getting rate limited by their Mastodon servers.