### PR TITLE
Initial support for reblogs

### DIFF
--- a/mastodon_to_sqlite/cli.py
+++ b/mastodon_to_sqlite/cli.py
@@ -183,8 +183,12 @@ def statuses(db_path, auth):
         show_pos=True,
     ) as bar:
         for statuses in bar:
+            reblogs = service.extract_reblogs(statuses)
+            accounts = [d["account"] for d in reblogs]
+            service.save_accounts(db, accounts)
+            service.save_statuses(db, reblogs)
             service.save_statuses(db, statuses)
-            bar.pos = bar.pos + len(statuses) - 1
+            bar.pos = bar.pos + len(statuses) + len(reblogs) - 1
 
 
 @cli.command()

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -63,6 +63,7 @@ def test_transformer_status():
         "created_at": fixtures.STATUS_ONE["created_at"],
         "content": fixtures.STATUS_ONE["content"],
         "account_id": fixtures.STATUS_ONE["account"]["id"],
+        "reblog_of": None,
     }
 
 


### PR DESCRIPTION
* [ ] I don't love the [new code in `mastodon_to_sqlite/cli.py:statuses`](https://github.com/numist/mastodon-to-sqlite/blob/ebd33590b28a5ff70f896449cc12fea835187008/mastodon_to_sqlite/cli.py#L186-L189) but to do otherwise would be a pretty major refactor so myles should be involved in that, but it seems worth doing?[^refactor]
* [ ] Datasette does not infer that `statuses.reblog_of` is a reference to `statuses.id`, is this something that can be improved by changing the schema or is this a [metadata](https://docs.datasette.io/en/1.0a2/metadata.html) kind of problem?
* [ ] The question of schema migration is back

[^refactor]: Favouriting or bookmarking a reblog (if not already possible) will probably become a semantically meaningful thing when Mastodon deploys quotes, assuming they're implemented as reblogs having non-empty `content` keys