### PR TITLE
📈 Added interaction counts to statuses

### DIFF
--- a/mastodon_to_sqlite/service.py
+++ b/mastodon_to_sqlite/service.py
@@ -68,6 +68,9 @@ def build_database(db: Database):
                 "account_id": int,
                 "content": str,
                 "created_at": str,
+                "replies_count": int,
+                "favourites_count": int,
+                "reblogs_count": int,
             },
             pk="id",
             foreign_keys=(("account_id", "accounts", "id"),),
@@ -234,6 +237,9 @@ def transformer_status(status: Dict[str, Any]):
         "id",
         "created_at",
         "content",
+        "reblogs_count",
+        "favourites_count",
+        "replies_count",
     )
     to_remove = [k for k in status.keys() if k not in to_keep]
     for key in to_remove:

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -63,6 +63,8 @@ def test_transformer_status():
         "created_at": fixtures.STATUS_ONE["created_at"],
         "content": fixtures.STATUS_ONE["content"],
         "account_id": fixtures.STATUS_ONE["account"]["id"],
+        "replies_count": fixtures.STATUS_ONE["replies_count"],
+        "reblogs_count": fixtures.STATUS_ONE["reblogs_count"],
     }
 
 


### PR DESCRIPTION
It would be extremely useful to have the reblog, favorite, and reply counts included in the status rows. This PR adds this, and updates the tests accordingly.