### PR TITLE
Add -u flag for only updating new statuses

### DIFF
--- a/mastodon_to_sqlite/cli.py
+++ b/mastodon_to_sqlite/cli.py
@@ -165,7 +165,15 @@ def followings(db_path, auth):
     default="auth.json",
     help="Path to auth.json token file",
 )
-def statuses(db_path, auth):
+@click.option(
+    "-u",
+    "--update",
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help="Update existing statuses",
+)
+def statuses(db_path, auth, update):
     """
     Save statuses for the authenticated user.
     """
@@ -177,8 +185,12 @@ def statuses(db_path, auth):
 
     service.save_accounts(db, [authenticated_account])
 
+    since_id = None
+    if update:
+        since_id = service.get_most_recent_status_id(db)
+
     with click.progressbar(
-        service.get_statuses(account_id, client),
+        service.get_statuses(account_id, client, since_id=since_id),
         label="Importing statuses",
         show_pos=True,
     ) as bar:

--- a/mastodon_to_sqlite/client.py
+++ b/mastodon_to_sqlite/client.py
@@ -1,6 +1,6 @@
 import datetime
 from time import sleep
-from typing import Generator, Optional, Tuple
+from typing import Dict, Generator, Optional, Tuple
 
 from requests import PreparedRequest, Request, Response, Session
 from requests.auth import AuthBase

--- a/mastodon_to_sqlite/client.py
+++ b/mastodon_to_sqlite/client.py
@@ -29,9 +29,9 @@ class MastodonClient:
         self.session = Session()
         self.session.auth = MastodonAuth(access_token)
 
-        self.session.headers["User-Agent"] = (
-            "mastodon-to-sqlite (+https://github.com/myles/mastodon-to-sqlite)"
-        )
+        self.session.headers[
+            "User-Agent"
+        ] = "mastodon-to-sqlite (+https://github.com/myles/mastodon-to-sqlite)"
 
     def request(
         self,

--- a/mastodon_to_sqlite/service.py
+++ b/mastodon_to_sqlite/service.py
@@ -1,7 +1,7 @@
 import datetime
 import json
-from pathlib import Path
 import sqlite3
+from pathlib import Path
 from typing import Any, Dict, Generator, List, Optional
 
 from sqlite_utils.db import Database, Table

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -34,7 +34,7 @@ STATUS_ONE = {
 
 STATUS_TWO = {
     "id": "2",
-    "created_at": "2021-12-20T19:46:29.073Z",
+    "created_at": "2021-12-20T20:46:29.073Z",
     "content": "Sleds are for suckers! Just ride on my gut!",
     "account": ACCOUNT_TWO,
     "bookmarked": True,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -111,3 +111,16 @@ def test_save_multiple_activity_types(mock_db):
     assert mock_db["status_activities"].count == 4
     for row in mock_db["status_activities"].rows:
         assert row["account_id"] == 42
+
+
+def test_get_most_recent_status_id(mock_db):
+    result = service.get_most_recent_status_id(mock_db)
+    assert result is None
+
+    status_one = fixtures.STATUS_ONE.copy()
+    status_two = fixtures.STATUS_TWO.copy()
+
+    service.save_statuses(mock_db, [status_one, status_two])
+
+    result = service.get_most_recent_status_id(mock_db)
+    assert result == int(status_two["id"])


### PR DESCRIPTION
This ideally replaces #13, and adds an option to only update the statuses that are new since last seen.

I also ran `make lintfix` which is why the extra changes are there.