### PR TITLE
Fix typo and improve auth command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ foo@bar:~$ pip install mastodon-to-sqlite
 ## Authentication
 
 First you will need to create an application on your Mastodon server. You
-can find that on your Mastodon serer.
+can find that on your Mastodon server.
 
 ```console
 foo@bar:~$ mastodon-to-sqlite auth

--- a/mastodon_to_sqlite/cli.py
+++ b/mastodon_to_sqlite/cli.py
@@ -71,8 +71,8 @@ def verify_auth(auth):
     if service.verify_auth(auth) is True:
         click.echo("Successfully authenticated with the Mastodon server.")
     else:
-        click.echo(
-            "Failed to authenticated with the Mastodon server.", err=True
+        raise click.ClickException(
+            "Failed to authenticate with the Mastodon server."
         )
 
 

--- a/mastodon_to_sqlite/service.py
+++ b/mastodon_to_sqlite/service.py
@@ -160,7 +160,7 @@ def get_followings(
     account_id: str, client: MastodonClient
 ) -> Generator[List[Dict[str, Any]], None, None]:
     """
-    Get authenticated account's followers.
+    Get accounts that the authenticated user is following.
     """
     for request, response in client.accounts_following(account_id):
         yield response.json()
@@ -168,7 +168,7 @@ def get_followings(
 
 def transformer_account(account: Dict[str, Any]):
     """
-    Transformer a Mastodon account, so it can be safely saved to the SQLite
+    Transform a Mastodon account so it can be safely saved to the SQLite
     database.
     """
     to_remove = [
@@ -230,7 +230,7 @@ def get_statuses(
 
 def transformer_status(status: Dict[str, Any]):
     """
-    Transformer a Mastodon status, so it can be safely saved to the SQLite
+    Transform a Mastodon status so it can be safely saved to the SQLite
     database.
     """
     account = status.pop("account")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,14 +5,23 @@ from mastodon_to_sqlite import cli
 
 
 @pytest.mark.parametrize(
-    "verify_auth_return_value, expected_stdout_startswith",
+    "verify_auth_return_value, expected_stdout, expected_stderr, expected_exit_code",
     (
-        (True, "Successfully"),
-        (False, "Failed"),
+        (True, "Successfully authenticated with the Mastodon server.\n", "", 0),
+        (
+            False,
+            "",
+            "Error: Failed to authenticate with the Mastodon server.\n",
+            1,
+        ),
     ),
 )
 def test_verify_auth(
-    verify_auth_return_value, expected_stdout_startswith, mocker
+    verify_auth_return_value,
+    expected_stdout,
+    expected_stderr,
+    expected_exit_code,
+    mocker,
 ):
     mocker.patch(
         "mastodon_to_sqlite.cli.service.verify_auth",
@@ -24,4 +33,6 @@ def test_verify_auth(
         cli.verify_auth, ["--auth", "tests/fixture-auth.json"]
     )
 
-    assert result.stdout.startswith(expected_stdout_startswith)
+    assert result.stdout == expected_stdout
+    assert result.stderr == expected_stderr
+    assert result.exit_code == expected_exit_code


### PR DESCRIPTION
## Summary
- fix README typo
- raise `click.ClickException` when auth check fails
- update service docstrings
- improve CLI auth test

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6862cf617ee8832aab62eb60a2d2bef6